### PR TITLE
[refactor] 메일, 세팅 화면의 뒤로가기 기능 구현을 fragment back stack 사용 방식으로 변경

### DIFF
--- a/app/src/main/java/com/example/mailapp/ui/fragments/BottomMenuFragment.kt
+++ b/app/src/main/java/com/example/mailapp/ui/fragments/BottomMenuFragment.kt
@@ -5,11 +5,34 @@ import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.get
+import androidx.core.view.size
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
 import com.example.mailapp.R
 import com.example.mailapp.databinding.FragmentBottomMenuBinding
 import com.example.mailapp.viewmodels.MainMenuViewModel
 
+/**
+ * fragment back stack
+ *
+ * #addToBackStack -> 현재 트랜잭션의 상태를 backStack에 추가
+ * => transaction.addToBackStack().replace(fragment).commit()
+ * 의 경우는 commit 이전에 addToBackStack 이 호출되었으니, commit 이전 현상태를 저장하는 것
+ *
+ * #popBackStack(name or id, flag)
+ * [name or id]: default 는 null, -1 로 되어있다
+ * 전달해주지 않으면 기본 pop 기능이 실핸되는
+ *
+ * [flag]: 0이 default, name or id가 일치하는 backStack 을 제거
+ * POP_BACK_STACK_INCLUSIVE: name or id가 일치하는 fragment 와, 그 위의 fragment 까지 모두 제거
+ * => name or id 가 없다면 모든 backStack 을 제거
+ *
+ * #replace
+ * 기존 backstack 의 fragment 들이 모두 onDestroyView 된다
+ * 이때 뒤로가기 버튼을 누르면, 화면에는 현재 fragment 가 표시되지만, 기존 backStack 에 존재했던 onDestroyView 처리된 fragment 들이 onDestroy 되고(한번에? 차례로?,
+ * 모든 back stack fragment destroy 이후 현재 fragment 가 destroy 된다
+ *
+ */
 class BottomMenuFragment: BaseFragment<FragmentBottomMenuBinding, MainMenuViewModel>() {
 
     override val layoutResId: Int
@@ -19,13 +42,11 @@ class BottomMenuFragment: BaseFragment<FragmentBottomMenuBinding, MainMenuViewMo
     private val onBackPressedCallback = object: OnBackPressedCallback(true){
         override fun handleOnBackPressed() {
             Log.d("TAG", "onBackPressed at bottom menu")
-            when(childFragmentManager.fragments.firstOrNull()){
-                is SettingFragment -> { // setting fragment 가 top 일때 -> mail fragment replace
-                    viewModel.setSelectTab(vd.bottomNavigationView.menu[0].itemId)
-                }
-                is MailListFragment -> {}
-                else -> requireActivity().finish()
-            }
+            Log.d("TAG", "backStack size : ${childFragmentManager.backStackEntryCount}")
+            if(childFragmentManager.backStackEntryCount != 0) {
+                childFragmentManager.popBackStack()
+            }else
+                requireActivity().finish()
         }
     }
     override fun onAttach(context: Context) {
@@ -52,6 +73,10 @@ class BottomMenuFragment: BaseFragment<FragmentBottomMenuBinding, MainMenuViewMo
             viewModel.clickTab(it.itemId)
             true // 항목을 선택한 항목으로 표시하려면 true, 항목을 선택하지 않아야 하는 경우 false
         }
+
+        childFragmentManager.addOnBackStackChangedListener { // after add/push/pop
+            viewModel.backStackChanged(childFragmentManager.backStackEntryCount, childFragmentManager.fragments.firstOrNull()?.tag)
+        }
     }
 
     override fun bind() {
@@ -66,26 +91,42 @@ class BottomMenuFragment: BaseFragment<FragmentBottomMenuBinding, MainMenuViewMo
             }
         }
 
+        viewModel.checkTabIdx.observe(this) { event ->
+            event.getContentIfNotHandled()?.let {
+                if(it in 0 until vd.bottomNavigationView.menu.size)
+                    vd.bottomNavigationView.menu[it].isChecked = true
+            }
+        }
+
         viewModel.showMailList.observe(this){ event ->
             event.getContentIfNotHandled()?.let {
+                //모든 backStack 을 제거한다 -> mail 에서 뒤로가기를 누르면 앱이 종료되어야 한다
+                childFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
                 childFragmentManager.beginTransaction()
-                    .replace(R.id.containerFragmentBottomMenu, MailListFragment())
+                    .replace(R.id.containerFragmentBottomMenu, MailListFragment(), it)
                     .commit()
             }
         }
         viewModel.showSetting.observe(this){ event ->
             event.getContentIfNotHandled()?.let {
-                Log.d("TAG", "extra data bundle nick[${arguments?.getString(SettingFragment.nicknameExtraKey)}] email[${arguments?.getString(SettingFragment.emailExtraKey)}]")
-                childFragmentManager.beginTransaction()
-                    .replace(
-                        R.id.containerFragmentBottomMenu,
-                        SettingFragment.get(
-                            arguments?.getString(SettingFragment.nicknameExtraKey),
-                            arguments?.getString(SettingFragment.emailExtraKey)
-                        )
-                    )
-                    .commit()
+                replaceSettingFragment(it)
             }
         }
+    }
+    private fun replaceSettingFragment(tag: String){
+        Log.d("TAG", "extra data bundle nick[${arguments?.getString(SettingFragment.nicknameExtraKey)}] email[${arguments?.getString(SettingFragment.emailExtraKey)}]")
+        //setting 에서 뒤로가기를 누르면 mail 로 이동해야하니, 기존에 setting tag 의 backStack 과, 그 위의 backStack 들을 제거하고, add backStack 해준다
+        childFragmentManager.popBackStack(SettingFragment.TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        childFragmentManager.beginTransaction()
+            .replace(
+                R.id.containerFragmentBottomMenu,
+                SettingFragment.get(
+                    arguments?.getString(SettingFragment.nicknameExtraKey),
+                    arguments?.getString(SettingFragment.emailExtraKey)
+                ),
+                tag
+            )
+            .addToBackStack(SettingFragment.TAG) // 현재 시점의 transaction 상태를 backStack 에 저장
+            .commit()
     }
 }

--- a/app/src/main/java/com/example/mailapp/ui/fragments/SettingFragment.kt
+++ b/app/src/main/java/com/example/mailapp/ui/fragments/SettingFragment.kt
@@ -12,6 +12,7 @@ import com.example.mailapp.viewmodels.SettingViewModel
 
 class SettingFragment: BaseFragment<FragmentSettingBinding, SettingViewModel>() {
     companion object {
+        const val TAG = "setting_fragment"
         const val nicknameExtraKey = "EXTRA_NICKNAME"
         const val emailExtraKey = "EXTRA_EMAIL"
         fun get(nickname: String?, email: String?): SettingFragment{
@@ -36,13 +37,13 @@ class SettingFragment: BaseFragment<FragmentSettingBinding, SettingViewModel>() 
     }
 
     override fun bind() {
-        viewModel.finishViewEvent.observe(this){ event ->
-            event.getContentIfNotHandled()?.let {
-                if(it.isNotBlank()){
-                    DialogUtil.show(mContext ?: return@let, it, getString(R.string.btn_close)){ }
-                }
-            }
-        }
+//        viewModel.finishViewEvent.observe(this){ event ->
+//            event.getContentIfNotHandled()?.let {
+//                if(it.isNotBlank()){
+////                    DialogUtil.show(mContext ?: return@let, it, getString(R.string.btn_close)){ }
+//                }
+//            }
+//        }
 
         viewModel.nickname.observe(this){
             vd.tvNickname.text = it

--- a/app/src/main/java/com/example/mailapp/viewmodels/MainMenuViewModel.kt
+++ b/app/src/main/java/com/example/mailapp/viewmodels/MainMenuViewModel.kt
@@ -6,30 +6,85 @@ import androidx.lifecycle.MutableLiveData
 import com.example.mailapp.R
 import com.example.mailapp.model.SingleEvent
 
+/**
+ *  가로 세로가 전환되면서 bottom, rail 이 서로 바뀔때 setting 이 먼저 표시되는 경우
+ *  addToBackStack 으로 인해 backStack 이 추가가 되긴하는데, 그때의 트랜잭션 상태는 mail 이 붙어있는 경우가 아니고, 그냥 빈 트랜잭션 상태이기 때문에
+ *  backPressed 를 진행했을때 pop 은 되지만, pop 되었을때 트랜잭션에 붙어있는 fragment 가 없기 때문에 빈 화면이 보여진다
+ *
+ *  => 해결은 어떻게?
+ *  1. setting fragment 를 replace 할때 backStack 이 비어있다면 default tab fragment - setting 순으로 replace?
+ *      => backStack 을 통째로 보관해서 붙여넣는 방법을 찾아야 한다
+ *      => 아니면, backStack 과 동일한 stack 을 따로 유지하다가, 화면 재구성시 해당 stack 대로 fragment 를 구성해줘야 한다
+ *  2. pop 시 fragment 가 붙은게 없는 트랜잭션 이라면, default tab 을 show?
+ *      => 언제나 pop 이후 빈 트랜잭션이라면 default fragment 를 보여준다?
+ *      => 해당 방식으로 구현 성공
+ *      => 현 상태에는 이렇게 해결이 가능하지만, fragment 가 3개 이상이며, 각각의 백스택을 유지해야하는 경우는 꽤 곤란할 것 같다
+ */
 class MainMenuViewModel: BaseViewModel() {
     private val _selectTabId: MutableLiveData<SingleEvent<Int>> = MutableLiveData()
     val selectTabId: LiveData<SingleEvent<Int>> = _selectTabId
 
-    private val _showMailList: MutableLiveData<SingleEvent<Unit>> = MutableLiveData()
-    val showMailList: LiveData<SingleEvent<Unit>> = _showMailList
+    private val _checkTabIdx: MutableLiveData<SingleEvent<Int>> = MutableLiveData()
+    val checkTabIdx: LiveData<SingleEvent<Int>> = _checkTabIdx
 
-    private val _showSetting: MutableLiveData<SingleEvent<Unit>> = MutableLiveData()
-    val showSetting: LiveData<SingleEvent<Unit>> = _showSetting
+    private val _showMailList: MutableLiveData<SingleEvent<String>> = MutableLiveData()
+    val showMailList: LiveData<SingleEvent<String>> = _showMailList
+
+    private val _showSetting: MutableLiveData<SingleEvent<String>> = MutableLiveData()
+    val showSetting: LiveData<SingleEvent<String>> = _showSetting
 
     /**
      * data
      */
-    private var currentSelectTabId: Int? = null
+    private var currentSelectTabId: Int = MenuItem.Mail.id
+    private var backStackCount = 0
+    enum class MenuItem(
+        val index: Int,
+        val id: Int,
+        val tag: String
+    ){
+        Mail(0, R.id.menu_mail, "menuList"),
+        Setting(1, R.id.menu_setting, "setting");
+        companion object {
+            operator fun get(id: Int): MenuItem? {
+                values().forEach { if(it.id == id) return it }
+                return null
+            }
+            operator fun get(tag: String?): MenuItem? {
+                values().forEach { if(it.tag == tag) return it }
+                return null
+            }
+        }
+    }
 
     /**
      * event from view
      */
     fun setDefaultTab(){
-        _selectTabId.value = SingleEvent(currentSelectTabId ?: -1)
+        _selectTabId.value = SingleEvent(currentSelectTabId)
     }
 
     fun setSelectTab(id: Int) {
         _selectTabId.value = SingleEvent(id)
+    }
+
+    fun backStackChanged(currentSize: Int, currentTag: String?){
+        Log.d("TAG", "backstack debug addOnBackStackChangedListener => stack size[$currentSize], prevCount[$backStackCount]")
+        when{
+            currentSize < backStackCount -> { // pop
+                Log.d("TAG", "pop back stack")
+                if(currentTag.isNullOrBlank()) { // 빈 트랜잭션 상태라면(setting fragment 에서 기기가 회전된다면, mail 이전에 add back stack -> replace setting 이 진행되어서 이런 경우가 발생)
+                    currentSelectTabId = MenuItem.Mail.id
+                    setDefaultTab()
+                } else
+                    setCheckTab(currentTag)
+            }
+        }
+        backStackCount = currentSize
+    }
+    private fun setCheckTab(tag: String?){
+        Log.d("TAG", "set check tab tag[$tag]")
+        _checkTabIdx.value = SingleEvent(MenuItem[tag]?.index ?: -1)
     }
 
     fun clickTab(id: Int){
@@ -37,10 +92,10 @@ class MainMenuViewModel: BaseViewModel() {
         currentSelectTabId = id
         when(id){
             R.id.menu_mail -> {
-                _showMailList.value = SingleEvent(Unit)
+                _showMailList.value = SingleEvent(MenuItem[id]?.tag ?: return)
             }
             R.id.menu_setting -> {
-                _showSetting.value = SingleEvent(Unit)
+                _showSetting.value = SingleEvent(MenuItem[id]?.tag ?: return)
             }
         }
     }


### PR DESCRIPTION
 - setting fragment 를 replace하기 전 상태를 backStack에 저장. 동일한 상태가 중첩되어 저장될 수 있으니, name을 지정하여, backStack에 저장하기 전 해당 name까지의 backStack을 제거 -> singleTop flag 와 비슷한 방식
 - mail fragment를 replace할때는, backStack을 비워준다 -> mail fragment가 root가 될 수 있도록
 - backStack pop을 통해 fragment가 변경될때, navigation menu의 클릭상태를 동일하게 맞춰주기 위해, pop이후 현재 최상단의 fragment 정보를 확인하여 해당 정보와 일치하는 navigation menu를 checked 상태로 변경시켜 주도록 수정
 - 2개의 menu fragment를 동일한 상태로 맞춰줘야 하는데, 기기 회전으로 인한 재구성시 backStack 정보가 유실되는 문제 존재.
 => 해결을 위해 backStack pop시 최상단의 fragment 정보가 없다면, 강제로 mail fragment를 root로 설정해서 replace 해주도록 수정
 => 현재의 요구사항에는 일치하는 해결 방안이지만, fragment가 3개 이상이되고, 각각의 backStack을 모두 저장해야 할때는 어떻게 해결애햐 할지 고민이 된다